### PR TITLE
Ensure filepaths are sorted in barrel.ts

### DIFF
--- a/src/vs-code-api.ts
+++ b/src/vs-code-api.ts
@@ -77,7 +77,9 @@ export class VsCodeApi implements IVsCodeApi {
 
   public async findSupportedFiles(folderPath: string): Promise<Array<string>> {
     const files = await vscode.workspace.findFiles(new vscode.RelativePattern(folderPath, '**/*.{js,jsx,ts,tsx,vue}'));
-    return files.map(f => f.path);
+    const filePaths = files.map(f => f.path);
+    filePaths.sort();
+    return filePaths;
   }
 
   public async findFiles(searchGlob: string): Promise<Array<string>> {


### PR DESCRIPTION
Thanks for making this extension, I use it everyday!! :+1:  

The only issue I've found is in Ubuntu Linux (and possibly other systems) the extension doesn't order the import filepaths. As you can see below (after I click update barrel, the filepaths are in a somewhat random order).

![Peek 2021-03-17 10-24](https://user-images.githubusercontent.com/11782590/111394741-3ba52200-870b-11eb-9d87-5ab4458a749a.gif)

Ordering will produce predictable index.ts files and will reduce conflicts when merging changes from multiple branches.

Cheers,
Ben